### PR TITLE
Remove empty values ('' is empty to)

### DIFF
--- a/adyengo/utils.py
+++ b/adyengo/utils.py
@@ -31,7 +31,7 @@ def merchant_sig(params, clean_params=True):
         return {
             key: value
             for key, value in params.items()
-            if value is not None
+            if value
         }
 
     if clean_params:


### PR DESCRIPTION
From doc https://docs.adyen.com/developers/hpp-manual#hpppaymentfields

`If a key value is null or if it is an empty value, do not submit it (recommended). If you do need or want to submit it, make sure the value is an empty string ("").`


So at simple hpp when `recurringContract` are not required signature calculated incorrectly (`recurring_contract` are not nullable).(https://github.com/gitaarik/adyengo/blob/master/adyengo/models.py#L96)